### PR TITLE
Update Record.pm

### DIFF
--- a/lib/Hex/Record.pm
+++ b/lib/Hex/Record.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '0.08';
+our $VERSION = '0.09';
 
 sub new {
     my ($class, %args) = @_;
@@ -18,7 +18,7 @@ sub import_intel_hex {
     my ($self, $hex_string) = @_;
 
     my $addr_high_dec = 0;
-
+    my $createPart = 0;
     for my $line (split m{\n\r?}, $hex_string) {
         my ($addr, $type, $bytes_str) = $line =~ m{
 		  : # intel hex start
@@ -33,15 +33,18 @@ sub import_intel_hex {
 
         # data line?
         if ($type == 0) {
-            $self->write($addr_high_dec + hex $addr, \@bytes);
+            $self->write($addr_high_dec + hex $addr, \@bytes, $createPart);
+            $createPart = 0;
         }
         # extended linear address type?
         elsif ($type == 4) {
             $addr_high_dec = hex( join '', @bytes ) << 16;
+            $createPart = 1;
         }
         # extended segment address type?
         elsif ($type == 2) {
             $addr_high_dec = hex( join '', @bytes ) << 4;
+            $createPart = 1;
         }
     }
 
@@ -91,8 +94,9 @@ sub import_srec_hex {
 }
 
 sub write {
-    my ($self, $from, $bytes_hex_ref) = @_;
-
+    my ($self, $from, $bytes_hex_ref, $createPart) = @_;
+    $createPart ||= 0;
+    
     $self->remove($from, scalar @$bytes_hex_ref);
 
     my $to = $from + @$bytes_hex_ref;
@@ -104,12 +108,12 @@ sub write {
         my $end_addr   = $part->{start} + $#{ $part->{bytes} };
 
         # merge with this part
-        if ($to == $start_addr) {
+        if ($createPart == 0 && $to == $start_addr) {
             $part->{start} = $from;
             unshift @{ $part->{bytes} }, @$bytes_hex_ref;
             return;
         }
-        elsif ($from == $end_addr + 1) {
+        elsif ($createPart == 0 && $from == $end_addr + 1) {
             push @{ $part->{bytes} }, @$bytes_hex_ref;
 
             return if $part_i+1 == @{ $self->{parts} };


### PR DESCRIPTION
hello @spebern ,
in the current implementation, the constructor method from class Record merges adjacent sections when opening the original hex file. 
i have modified the write function so that it still merges the adjacent sections when it is called, unless this section was already existing in the original hex file (after a 02 or 04 code is found). 
what do you think about this idea? 
in our system we needed this sections to be present in the final hex file. when two of the sections were adjacent, our system was not working properly. we have struggled a little bit until we found out the reason why. 
thank you in advance!